### PR TITLE
Ensure the font family is unique

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -691,7 +691,8 @@ class SiteOrigin_Settings {
 						}
 
 						// Clean up the arguments
-						$args['subset'] = array_unique($args['subset']);
+						$args['subset'] = array_unique( $args['subset'] );
+						$args['family'] = array_unique( $args['family'] );
 
 						$args['family'] = array_map( 'urlencode', $args['family'] );
 						$args['subset'] = array_map( 'urlencode', $args['subset'] );


### PR DESCRIPTION
This turns the web font import in SiteOrigin North from this:

![](https://i.imgur.com/d5lN3v4.png)


To this:
![](https://i.imgur.com/wOi7Y2P.png)
