### PR TITLE
Page Settigns: Ensure post has id before check

### DIFF
--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -177,6 +177,7 @@ class SiteOrigin_Settings_Page_Settings {
 		if (
 		    class_exists( 'WooCommerce' ) &&
 		    ! empty( $screen ) && $screen->id == 'page' &&
+		    isset( $_GET['post'] ) &&
 		    get_option( 'woocommerce_shop_page_id' ) == $_GET['post']
 		) {
 		    return;


### PR DESCRIPTION
This PR resolves: `Resolve ( ! ) Notice: Undefined index: post in C:\Users\Alex\Documents\local-sites\siteorigin\app\public\wp-content\themes\siteorigin-corp\inc\settings\inc\page_settings.php on line 180`