### PR TITLE
Add` siteorigin_page_settings_get_query_bypass`

### DIFF
--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -54,7 +54,7 @@ class SiteOrigin_Settings_Page_Settings {
 		static $type = false;
 		static $id = false;
 
-		if( is_main_query() && $type === false && $id === false ) {
+		if ( ( apply_filters( 'siteorigin_page_settings_get_query_bypass', false ) || is_main_query() ) && $type === false && $id === false ) {
 			list( $type, $id ) = self::get_current_page();
 		}
 

--- a/settings.php
+++ b/settings.php
@@ -821,6 +821,11 @@ class SiteOrigin_Settings {
 		if( is_admin() && has_filter( 'siteorigin_about_page' ) && apply_filters( 'siteorigin_about_page_show', true ) ) {
 			SiteOrigin_Settings_About_Page::single();
 		}
+
+		// Add 404page Page Settings Compatibility.
+		if ( function_exists( 'pp_404_is_active' ) ) {
+			add_filter( 'siteorigin_page_settings_get_query_bypass', 'pp_404_is_active' );
+		}
 	}
 
 	/**


### PR DESCRIPTION

This PR allows for developers to optionally override the is_main_query() check added in https://github.com/siteorigin/settings/pull/58. This PR was prompted by that change breaking page settings for [404page](https://wordpress.org/plugins/404page/) plugin.

Here's some test code that's written with 404page in mind:

```
add_filter( 'siteorigin_page_settings_get_query_bypass', function( $bypass ) {
	if ( function_exists( 'pp_404_is_active' ) ) {
		return pp_404_is_active();
	}
	return $bypass;
} );
```