### PR TITLE
Add "Lazy Load Exclude Logo" Extra

### DIFF
--- a/inc/lazy_load_exclude_logo.php
+++ b/inc/lazy_load_exclude_logo.php
@@ -17,7 +17,11 @@ class SiteOrigin_Settings_Lazy_Load_Exclude_Logo {
 	}
 
 	public function exclude_logo( $attr, $attachment ) {
-		$custom_logo_id = siteorigin_setting( 'branding_logo' );
+		$logo_setting = apply_filters( 'siteorigin_settings_lazy_load_exclude_logo_setting', 'branding_logo' );
+		if ( ! empty( $logo_setting ) ) {
+			$custom_logo_id = siteorigin_setting( $logo_setting );
+		}
+
 		if ( empty( $custom_logo_id ) ) {
 			$custom_logo_id = get_theme_mod( 'custom_logo' );
 		}

--- a/inc/lazy_load_exclude_logo.php
+++ b/inc/lazy_load_exclude_logo.php
@@ -36,7 +36,7 @@ class SiteOrigin_Settings_Lazy_load_Exclude_Logo {
 				$attr['data-no-lazy'] = 1;
 			}
 			// WP 5.5
-			$attr['loading'] = false;
+			$attr['loading'] = 'eager';
 		}
 		return $attr;
 	}

--- a/inc/lazy_load_exclude_logo.php
+++ b/inc/lazy_load_exclude_logo.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Exclude Logo from Lazy Load plugins.
+ */
+class SiteOrigin_Settings_Lazy_load_Exclude_Logo {
+
+	function __construct(){
+		add_filter( 'wp_get_attachment_image_attributes', array( $this, 'exclude_logo' ), 10, 2 );
+	}
+
+	static function single(){
+		static $single;
+		if( empty( $single ) ) {
+			$single = new self();
+		}
+		return $single;
+	}
+
+	public function exclude_logo( $attr, $attachment ) {
+		$custom_logo_id = siteorigin_setting( 'branding_logo' );
+		if ( empty( $custom_logo_id ) ) {
+			$custom_logo_id = get_theme_mod( 'custom_logo' );
+		}
+
+		if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
+			// Jetpack Lazy Load
+			if ( class_exists( 'Jetpack_Lazy_Images' ) || class_exists( 'Automattic\\Jetpack\\Jetpack_Lazy_Images' ) ) {
+				$attr['class'] .= ' skip-lazy';
+			}
+			// Smush Lazy Load
+			if ( class_exists( 'Smush\Core\Modules\Lazy' ) ) {
+				$attr['class'] .= ' no-lazyload';
+			}
+			// LiteSpeed Cache Lazy Load
+			if ( class_exists( 'LiteSpeed_Cache' ) || class_exists( 'LiteSpeed\Media' ) ) {
+				$attr['data-no-lazy'] = 1;
+			}
+			// WP 5.5
+			$attr['loading'] = false;
+		}
+		return $attr;
+	}
+}

--- a/inc/lazy_load_exclude_logo.php
+++ b/inc/lazy_load_exclude_logo.php
@@ -2,15 +2,15 @@
 /**
  * Exclude Logo from Lazy Load plugins.
  */
-class SiteOrigin_Settings_Lazy_load_Exclude_Logo {
+class SiteOrigin_Settings_Lazy_Load_Exclude_Logo {
 
-	function __construct(){
+	function __construct() {
 		add_filter( 'wp_get_attachment_image_attributes', array( $this, 'exclude_logo' ), 10, 2 );
 	}
 
-	static function single(){
+	static function single() {
 		static $single;
-		if( empty( $single ) ) {
+		if ( empty( $single ) ) {
 			$single = new self();
 		}
 		return $single;

--- a/settings.php
+++ b/settings.php
@@ -823,7 +823,7 @@ class SiteOrigin_Settings {
 		}
 
 		if ( ! is_admin() && has_filter( 'siteorigin_settings_lazy_load_exclude_logo' ) ) {
-			SiteOrigin_Settings_Lazy_load_Exclude_Logo::single();
+			SiteOrigin_Settings_Lazy_Load_Exclude_Logo::single();
 		}
 	}
 

--- a/settings.php
+++ b/settings.php
@@ -821,6 +821,10 @@ class SiteOrigin_Settings {
 		if( is_admin() && has_filter( 'siteorigin_about_page' ) && apply_filters( 'siteorigin_about_page_show', true ) ) {
 			SiteOrigin_Settings_About_Page::single();
 		}
+
+		if ( ! is_admin() && has_filter( 'siteorigin_settings_lazy_load_exclude_logo' ) ) {
+			SiteOrigin_Settings_Lazy_load_Exclude_Logo::single();
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR adds the Lazy Load logo exclusion code we were previously using in North, Corp, and Unwind into the Settings Library. It adds. To enable it, add the following to the theme:

`add_filter( 'siteorigin_settings_lazy_load_exclude_logo', '__return_true' );`
