### PR TITLE
 RGBA Fix: Add missing semi-colon to ensure CSS correct.

### DIFF
--- a/inc/css_functions.php
+++ b/inc/css_functions.php
@@ -60,7 +60,7 @@ class SiteOrigin_Settings_CSS_Functions {
 		}
 
 		$rgb = SiteOrigin_Settings_Color::hex2rgb( trim( $args[0] ) );
-		return 'rgba(' . implode( ',', array_merge( $rgb, array( floatval( $args[1] ) ) ) ) . ')';
+		return 'rgba(' . implode( ',', array_merge( $rgb, array( floatval( $args[1] ) ) ) ) . ');';
 	}
 
 	function lighten( $match ) {


### PR DESCRIPTION
This PR resolves an issue where any CSS added on the next line after a .rgba() will become invalid due to the missing semi-colon. For example, [the North Responsive Background when a Menu font is set](https://github.com/siteorigin/siteorigin-north/blob/40cf1861887e773da9bbad8bd4465673c2a343f5/inc/settings.php#L666-L669).

![2021-02-10_03-41-10-1414](https://user-images.githubusercontent.com/17275120/107404263-d4b3ac80-6b51-11eb-8dbc-52d442856a23.png)
