### PR TITLE
Enqueue Google Fonts instead of @import. Also Set Font Display

### DIFF
--- a/inc/css_functions.php
+++ b/inc/css_functions.php
@@ -23,16 +23,6 @@ class SiteOrigin_Settings_CSS_Functions {
 			return '';
 		}
 
-		if( $args['webfont'] ) {
-			// We need to import this too
-			$query = add_query_arg(array(
-				'family' => rawurlencode( $args['font'] ) . ':' . rawurlencode( $args['variant'] ),
-				'subset' => rawurlencode( $args['subset'] )
-			), '//fonts.googleapis.com/css');
-			$return .= '@import url(' . $query . '); ';
-		}
-
-		// Now lets add all the css styling
 		$return .= 'font-family: "' . esc_attr( $args['font'] ) . '", ' . $args['category'] . '; ';
 		if( strpos( $args['variant'], 'italic' ) !== false ) {
 			$weight = str_replace('italic', '', $args['variant']);

--- a/inc/webfont_manager.php
+++ b/inc/webfont_manager.php
@@ -27,8 +27,13 @@ class SiteOrigin_Settings_Webfont_Manager {
 				'subset' => $subset,
 			);
 		} else {
-			$this->fonts[ $name ] = array_merge( $this->fonts[$name], $weights );
-			$this->fonts[ $name ] = array_unique( $this->fonts[$name] );
+			if ( isset( $this->fonts[ $name ]['variants'] ) ) {
+				$this->fonts[ $name ]['variants'] = array_merge( $this->fonts[ $name ]['variants'], $weights );
+				$this->fonts[ $name ]['variants'] = array_unique( $this->fonts[ $name ]['variants'] );
+			} else {
+				$this->fonts[ $name ]['variants'] = $weights;
+			}
+			$this->fonts[ $name ] = array_unique( $this->fonts[ $name ] );
 		}
 	}
 

--- a/inc/webfont_manager.php
+++ b/inc/webfont_manager.php
@@ -33,7 +33,7 @@ class SiteOrigin_Settings_Webfont_Manager {
 			} else {
 				$this->fonts[ $name ]['variants'] = $weights;
 			}
-			$this->fonts[ $name ] = array_unique( $this->fonts[ $name ] );
+			$this->fonts[ $name ] = array_unique( $this->fonts[ $name ], SORT_REGULAR );
 		}
 	}
 

--- a/inc/webfont_manager.php
+++ b/inc/webfont_manager.php
@@ -63,7 +63,13 @@ class SiteOrigin_Settings_Webfont_Manager {
 
 		wp_enqueue_style(
 			'siteorigin-google-web-fonts',
-			add_query_arg('family', implode( '|', $family ), '//fonts.googleapis.com/css')
+			add_query_arg(
+				array(
+				    'family' => implode( '|', $family ),
+				    'display' => 'block',
+				),
+				'//fonts.googleapis.com/css'
+			)
 		);
 	}
 


### PR DESCRIPTION
This PR enqueues fonts instead of `@import`ing them.

It also sets Font Display which is required to avoid [a Google performance flag](https://web.dev/font-display/). The value is based on https://github.com/siteorigin/so-widgets-bundle/pull/1072/files

[Related](https://github.com/siteorigin/vantage/pull/381)