### PR TITLE
Add Page Settings Metabox for WooCommerce Products

### DIFF
--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -79,6 +79,9 @@ class SiteOrigin_Settings_Page_Settings {
 	function add_page_settings_support(){
 		add_post_type_support( 'page', 'so-page-settings' );
 		add_post_type_support( 'post', 'so-page-settings' );
+		if ( function_exists( 'is_woocommerce' ) ) {
+			add_post_type_support( 'product', 'so-page-settings' );
+		}
 		if ( post_type_exists( 'jetpack-portfolio' ) ) {
 			add_post_type_support( 'jetpack-portfolio', 'so-page-settings' );
 		}


### PR DESCRIPTION
Tested with Vantage and SiteOrigin Corp and didn't notice any issues with adjusting margins and page layout.