### PR TITLE
Page Settings: Pass Post Type To Allow Filtering

### DIFF
--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -15,7 +15,7 @@ class SiteOrigin_Settings_Page_Settings {
 
 		// All the meta box stuff
 		add_action( 'add_meta_boxes', array($this, 'add_meta_box'), 10 );
-		add_action( 'save_post', array($this, 'save_post') );
+		add_action( 'save_post', array($this, 'save_post'), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'register_css' ) );
 
 		// Page Builder integration
@@ -198,9 +198,9 @@ class SiteOrigin_Settings_Page_Settings {
 	/**
 	 * Display the Meta Box
 	 */
-	function display_post_meta_box( $post ){
-		$settings = $this->get_settings( 'post', $post->ID );
-		$values = $this->get_settings_values( 'post', $post->ID );
+	function display_post_meta_box( $post ) {
+		$settings = $this->get_settings( $post->post_type, $post->ID );
+		$values = $this->get_settings_values( $post->post_type, $post->ID );
 
 		wp_enqueue_style( 'siteorigin-settings-metabox' );
 
@@ -252,14 +252,15 @@ class SiteOrigin_Settings_Page_Settings {
 	 *
 	 * @param $post_id
 	 */
-	function save_post( $post_id ){
+	function save_post( $post_id, $post ) {
 		if( !current_user_can( 'edit_post', $post_id ) ) return;
 		if( empty($_POST['_so_page_settings_nonce']) || !wp_verify_nonce( $_POST['_so_page_settings_nonce'], 'save_page_settings' ) ) return;
 		if( empty($_POST['so_page_settings']) ) return;
 
 		$settings = stripslashes_deep( $_POST['so_page_settings'] );
+		$post_type = ! wp_is_post_revision( $post_id ) ? $post->post_type : get_post_type( $post->post_parent );
 
-		foreach( $this->get_settings( 'post', $post_id ) as $id => $field ) {
+		foreach( $this->get_settings( $post_type, $post_id ) as $id => $field ) {
 			switch( $field['type'] ) {
 				case 'select' :
 					if( !in_array( $settings[$id], array_keys( $field['options'] ) ) ) {

--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -157,7 +157,7 @@ class SiteOrigin_Settings_Page_Settings {
 				break;
 
 			default:
-				$values = get_theme_mod( 'page_settings_' . $type . '_' . $id );
+				$values = get_post_meta( $id, 'siteorigin_page_settings', true );
 				break;
 		}
 


### PR DESCRIPTION
This PR will pass the post type to get settings which will allow themes to filer what settings/defaults are used based on post type. Previously, it would only use 'post' which prevented this.

To test this, load this PR with Unwind and [replace these highlighted lines](https://github.com/siteorigin/siteorigin-unwind/blob/1.8.1/inc/settings.php#L1478-L1483) with:

```
	if ( $type != 'page' ) {
		$settings['display_masthead'] = array(
			'type'           => 'checkbox',
			'label'          => esc_html__( 'Header', 'siteorigin-unwind' ),
			'checkbox_label' => esc_html__( 'Enable', 'siteorigin-unwind' ),
			'description'    => esc_html__( 'Display the header and top bar.', 'siteorigin-unwind' )
		);
	}
```

Now view a post and page in the editor. You won't be able to alter the Header post setting for pages, but you will be able to for posts.
