### PR TITLE
Restore Page Template Settings for Archives

### DIFF
--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -152,10 +152,11 @@ class SiteOrigin_Settings_Page_Settings {
 		$defaults = $this->get_settings_defaults( $type, $id );
 
 		switch( $type ) {
-			case 'post':
-				$values = get_post_meta( $id, 'siteorigin_page_settings', true );
+			case 'archive':
+				$values = get_theme_mod( 'page_settings_' . $type . '_' . $id );
 				break;
 
+			case 'post':
 			default:
 				$values = get_post_meta( $id, 'siteorigin_page_settings', true );
 				break;


### PR DESCRIPTION
This is a follow up to https://github.com/siteorigin/settings/pull/75/commits/8fda98dfb40438f302cc4b82333a379732c544bc. That's resulted in Page Template settings not being used.

To test this PR:

- Activate WooCommerce.
- Navigate to the customizer and open the Shop page in the customizer preview.
- Navigate to **Page Template Settings > Type: Products** and disable the Page Title.

Prior to this PR, this setting won't take effect. After this PR, it will.