### PR TITLE
Restore Page Template Settings for Templates, and Taxonomies

### DIFF
--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -153,6 +153,8 @@ class SiteOrigin_Settings_Page_Settings {
 
 		switch( $type ) {
 			case 'archive':
+			case 'template':
+			case 'taxonomy':
 				$values = get_theme_mod( 'page_settings_' . $type . '_' . $id );
 				break;
 


### PR DESCRIPTION
This is a follow up to https://github.com/siteorigin/settings/commit/8fda98dfb40438f302cc4b82333a379732c544bc.  That resulted in Page Template settings not being used for templates (search page, 404 page, etc) and taxonomies.

To test this PR:

- Add widgets to the sidebar.
- Navigate to the customizer and open the Shop page in the customizer preview.
- Navigate to **Page Template Settings > Search Results** and change the **Page Layout** to **No Sidebar**.
- Save and open a new tab. Do a search and confirm the search sidebar isn't visible.
- Switch to this branch and confirm that the sidebar is now correctly hidden.
- Repeat the above steps for a taxonomy (you can skip opening a new tab though as it'll show in the customizer preview).

I've done a few additional checks and can confirm there are no other possible types for page template settings so they're all accounted for now.