### PR TITLE
WPML: Prevent Translated Settings From Having Source Text Overridden

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -97,6 +97,7 @@ class SiteOrigin_Settings {
 		$migrations = apply_filters( 'siteorigin_settings_migrated_settings', array(  ) );
 		if( empty( $migrations ) ) return;
 
+		$wpml_current_language = $this->wpml_language_override();
 		$migration_key = md5( serialize( $migrations ) );
 		if( $migration_key !== get_theme_mod( 'migration_key' ) ) {
 			foreach( $migrations as $to => $from ) {
@@ -110,6 +111,7 @@ class SiteOrigin_Settings {
 
 			set_theme_mod( 'migration_key', $migration_key );
 		}
+		$this->wpml_language_override( $wpml_current_language );
 	}
 
 	/**
@@ -163,14 +165,32 @@ class SiteOrigin_Settings {
 	}
 
 	/**
+	 * Check for WPML and Override Language.
+	 *
+	 * @param $action
+	 */
+	function wpml_language_override( $current_lang = false ) {
+		if ( class_exists( 'sitepress' ) ) {
+			if ( ! $current_lang ) {
+				$current_lang = apply_filters( 'wpml_current_language', NULL );
+				do_action( 'wpml_switch_language', apply_filters( 'wpml_default_language', null ) );
+				return $current_lang;
+			} else {
+				do_action( 'wpml_switch_language', $current_lang );
+			}
+		}
+	}
+	/**
 	 * Set a theme setting value. Simple wrapper for set theme mod.
 	 *
 	 * @param $setting
 	 * @param $value
 	 */
 	function set( $setting, $value ) {
+		$wpml_current_language = $this->wpml_language_override();
 		set_theme_mod( 'theme_settings_' . $setting, $value );
 		set_theme_mod( 'custom_css_key', false );
+		$this->wpml_language_override( $wpml_current_language );
 	}
 
 	/**
@@ -708,8 +728,10 @@ class SiteOrigin_Settings {
 				} while( $count > 0 );
 				$css = trim($css);
 
+				$wpml_current_language = $this->wpml_language_override();
 				set_theme_mod( 'custom_css', $css );
 				set_theme_mod( 'custom_css_key', $css_key );
+				$this->wpml_language_override( $wpml_current_language );
 			}
 			else {
 				$css = get_theme_mod('custom_css');


### PR DESCRIPTION
This PR will prevent Customizer settings from being overridden by their WPML translations.

Testing setup:
- Both WPML Multilingual CMS and WPML String Translation must be active. At least one other language must be set up.
- Have a page set up using the site default language and at least one other language.
- Test using SiteOrigin Corp

Navigate to `WPML > String Translation` and select the `admin-texts_theme_mods_siteorigin_corp` domain.
![2021-11-18_08-29-04-1610](https://user-images.githubusercontent.com/17275120/142292710-0049febf-8338-4935-a08c-6cd23606b8ab.jpg)

Can't find it? Do a general search for something that won't return any valid results (ie. `aaaaaaa`) and then click the `Can't find the strings you're looking to translate?` button. Click `Choose texts for translation` and search for the domain there. Navigate back to `WPML > String Translation` and select the `admin-texts_theme_mods_siteorigin_corp` domain 

Give the Footer text a translation for the non-default site language. Open the page setup using both languages.
Viewing the page using the site default will result in the Footer text being correct. Change to the second language and the text will be overridden (which is fine). Revert back to the base language and the Footer text will still be overridden - this is the issue.

Switch this PR and navigate to `Appearance > Customize`, `Theme Settings > Footer` and change the `Footer text` setting to something different than the override text. View the page in both languages and confirm that the text is no longer overridden on the base language page after viewing the second language.