### PR TITLE
 Allow Websafe Filter

### DIFF
--- a/inc/control/font.php
+++ b/inc/control/font.php
@@ -19,8 +19,8 @@ class SiteOrigin_Settings_Control_Font extends WP_Customize_Control {
 		if( empty($fonts) ) {
 			$fonts = include dirname(__FILE__) . '/../../data/fonts.php';
 		}
-		if( empty($websafe) ) {
-			$websafe = include dirname(__FILE__) . '/../../data/websafe.php';
+		if ( empty( $websafe ) ) {
+			$websafe = apply_filters( 'siteorigin_settings_websafe', include dirname( __FILE__ ) . '/../../data/websafe.php' );
 		}
 
 		?>
@@ -34,10 +34,14 @@ class SiteOrigin_Settings_Control_Font extends WP_Customize_Control {
 						<option
 							value="<?php echo esc_attr($name) ?>"
 							data-variants="<?php echo esc_attr( implode( ',', $attr['variants'] ) ) ?>"
-							data-subsets="<?php echo esc_attr( implode( ',', $attr['subsets'] ) ) ?>"
-							data-category="<?php echo esc_attr($attr['category']) ?>"
+							<?php if ( ! empty( $attr['subsets'] ) ) : ?>
+								data-subsets="<?php echo esc_attr( implode( ',', $attr['subsets'] ) ); ?>"
+							<?php endif; ?>
+							<?php if ( ! empty( $attr['category'] ) ) : ?>
+								data-category="<?php echo esc_attr( $attr['category'] ); ?>"
+							<?php endif; ?>
 							data-webfont="false"
-							style="font-family: '<?php echo esc_attr($name) ?>', <?php echo esc_attr($attr['category']) ?>, __websafe">
+							style="font-family: '<?php echo esc_attr($name) ?>', <?php echo ! empty( $attr['category'] ) ? esc_attr( $attr['category'] ) : ''; ?>, __websafe">
 							<?php echo esc_html($name) ?>
 						</option>
 					<?php endforeach; ?>
@@ -60,12 +64,12 @@ class SiteOrigin_Settings_Control_Font extends WP_Customize_Control {
 		</div>
 
 		<div class="field-wrapper">
-			<label><?php esc_html_e( 'Variant', 'siteorigin' ) ?></label>
+			<label><?php esc_html_e( 'Variant', 'siteorigin' ); ?></label>
 			<select class="font-variant"></select>
 		</div>
 
 		<div class="field-wrapper">
-			<label><?php esc_html_e( 'Subset', 'siteorigin' ) ?></label>
+			<label><?php esc_html_e( 'Subset', 'siteorigin' ); ?></label>
 			<select class="font-subset"></select>
 		</div>
 

--- a/inc/css_functions.php
+++ b/inc/css_functions.php
@@ -23,7 +23,7 @@ class SiteOrigin_Settings_CSS_Functions {
 			return '';
 		}
 
-		$return .= 'font-family: "' . esc_attr( $args['font'] ) . '", ' . $args['category'] . '; ';
+		$return .= 'font-family: "' . esc_attr( $args['font'] ) . '"' . ( ! empty( $args['category'] ) ? ', ' . $args['category'] : '' ) .'; ';
 		if( strpos( $args['variant'], 'italic' ) !== false ) {
 			$weight = str_replace('italic', '', $args['variant']);
 			$return .= 'font-style: italic; ';

--- a/inc/webfont_manager.php
+++ b/inc/webfont_manager.php
@@ -7,7 +7,7 @@ class SiteOrigin_Settings_Webfont_Manager {
 
 	function __construct() {
 		$this->fonts = array();
-		$this->websafe = include dirname( __FILE__ ) . '/../data/websafe.php';
+		$this->websafe = apply_filters( 'siteorigin_settings_websafe', include dirname( __FILE__ ) . '/../data/websafe.php' );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ) );
 	}


### PR DESCRIPTION
North/Unwind/Corp version of https://github.com/siteorigin/vantage/pull/417

This PR adds `siteorigin_settings_websafe` that allow filtering of websafe fonts. This also indirectly allows users to add custom font - they handle the actual adding of fonts externally.

Test snippet:

```
add_filter( 'siteorigin_settings_websafe', function( $websafe ) {
	$websafe['Custom Font'] = array(
		'variants' => array (
			'200',
			'500',
			'900',
		),
	);

	return $websafe;
} );
```