### PR TITLE
Add Support For `siteorigin_web_font_url`

### DIFF
--- a/inc/webfont_manager.php
+++ b/inc/webfont_manager.php
@@ -89,7 +89,7 @@ class SiteOrigin_Settings_Webfont_Manager {
 					'subset' => implode( ',', $subset ),
 					'display' => 'block',
 				),
-				'//fonts.googleapis.com/css'
+				esc_url( apply_filters( 'siteorigin_web_font_url', 'https://fonts.googleapis.com/css' ) )
 			)
 		);
 	}

--- a/settings.php
+++ b/settings.php
@@ -681,7 +681,7 @@ class SiteOrigin_Settings {
 					$webfont_imports = array();
 
 					for( $i = 0; $i < count($matches[0]); $i++ ) {
-						if( strpos('//fonts.googleapis.com/css', $matches[1][$i]) !== -1 ) {
+						if ( strpos( '//fonts.googleapis.com/css', $matches[1][ $i ] ) !== -1 ) {
 							if ( ! in_array( $matches[1][ $i ], $webfont_imports ) ) {
 								$webfont_imports[] = $matches[1][$i];
 							}
@@ -717,7 +717,7 @@ class SiteOrigin_Settings {
 						$args['family'] = implode('|', $args['family']);
 						$args['subset'] = implode(',', $args['subset']);
 
-						$import = '@import url(' . add_query_arg( $args, '//fonts.googleapis.com/css' ) . ');';
+						$import = '@import url(' . esc_url( add_query_arg( $args, apply_filters( 'siteorigin_web_font_url', 'https://fonts.googleapis.com/css' ) ) ) . ');';
 						$css = $import . "\n" . $css;
 					}
 				}


### PR DESCRIPTION
This PR will allow users to replace Google Fonts with GDPR-friendly mirrors such as [Bunny Fonts](https://fonts.bunny.net/).

Test snippet:
```
add_filter( 'siteorigin_web_font_url ', function( $url ) {
	return 'https://fonts.bunny.net/css';
} );
```

To test this snippet please add this branch into Corp, Unwind or North, and set the Body text to a Google Fonts hosted font.