### PR TITLE
`create_css`: Add `each` Function To Restore PHP 8 Compatibility

### DIFF
--- a/bin/create_css.php
+++ b/bin/create_css.php
@@ -5,17 +5,19 @@ include dirname( __FILE__ ) . '/inc/recursive_copy.php';
 
 // PHP 8 Compatibility function required by cssmin.
 // https://www.php.net/manual/en/function.each.php#126076
-function each( $array ) {
-	$key = key( $array );
-	$value = current( $array );
-	$each = is_null( $key ) ? false : array(
-		1        => $value,
-		'value'  => $value,
-		0        => $key,
-		'key'    => $key,
-	);
-	next( $array );
-	return $each;
+if ( ! function_exists( 'each' ) ) {
+	function each( $array ) {
+		$key = key( $array );
+		$value = current( $array );
+		$each = is_null( $key ) ? false : array(
+			1        => $value,
+			'value'  => $value,
+			0        => $key,
+			'key'    => $key,
+		);
+		next( $array );
+		return $each;
+	}
 }
 include dirname( __FILE__ ) . '/inc/cssmin.php';
 

--- a/bin/create_css.php
+++ b/bin/create_css.php
@@ -2,6 +2,21 @@
 <?php
 
 include dirname( __FILE__ ) . '/inc/recursive_copy.php';
+
+// PHP 8 Compatibility function required by cssmin.
+// https://www.php.net/manual/en/function.each.php#126076
+function each( $array ){
+	$key = key( $array );
+	$value = current( $array );
+	$each = is_null( $key ) ? false : array(
+		1        => $value,
+		'value'  => $value,
+		0        => $key,
+		'key'    => $key,
+	);
+	next( $array );
+	return $each;
+}
 include dirname( __FILE__ ) . '/inc/cssmin.php';
 
 $conf = include dirname( __FILE__ ) . '/../../settings.conf.php';

--- a/bin/create_css.php
+++ b/bin/create_css.php
@@ -5,7 +5,7 @@ include dirname( __FILE__ ) . '/inc/recursive_copy.php';
 
 // PHP 8 Compatibility function required by cssmin.
 // https://www.php.net/manual/en/function.each.php#126076
-function each( $array ){
+function each( $array  ){
 	$key = key( $array );
 	$value = current( $array );
 	$each = is_null( $key ) ? false : array(

--- a/bin/create_css.php
+++ b/bin/create_css.php
@@ -5,7 +5,7 @@ include dirname( __FILE__ ) . '/inc/recursive_copy.php';
 
 // PHP 8 Compatibility function required by cssmin.
 // https://www.php.net/manual/en/function.each.php#126076
-function each( $array  ){
+function each( $array ) {
 	$key = key( $array );
 	$value = current( $array );
 	$each = is_null( $key ) ? false : array(


### PR DESCRIPTION
https://www.php.net/manual/en/function.each.php#126076. Related https://www.php.net/manual/en/function.each.php.
A quick and simple fix. A proper fix would be to swap out with a more modern build method.