### PR TITLE
Add Central Breadcrumbs

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -891,3 +891,27 @@ function siteorigin_setting( $setting ) {
 function siteorigin_settings_set( $setting, $value ) {
 	SiteOrigin_Settings::single()->set( $setting, $value );
 }
+
+/**
+ * Display's breadcrumbs supported by Breadcrumb NavXT, Rank Math, and Yoast SEO.
+ */
+function siteorigin_settings_breadcrumbs( $class = null ) {
+	if ( function_exists( 'bcn_display' ) ) {
+		?>
+		<div id="navxt-breadcrumbs" class="breadcrumbs bcn<?php echo $class; ?>">
+			<?php bcn_display(); ?>
+		</div>
+	<?php
+	} elseif ( function_exists( 'yoast_breadcrumb' ) ) {
+		yoast_breadcrumb( "<div id='yoast-breadcrumbs' class='breadcrumbs$class'>", '</div>' );
+	} elseif ( function_exists( 'rank_math_the_breadcrumbs' ) ) {
+		$rank_math_breadcrumbs = rank_math_get_breadcrumbs();
+		if ( ! empty( $rank_math_breadcrumbs ) ) {
+			?>
+			<div id="rank_math-breadcrumbs" class="breadcrumbs<?php echo $class; ?>">
+				<?php echo $rank_math_breadcrumbs; ?>
+			</div>
+			<?php
+		}
+	}
+}


### PR DESCRIPTION
This PR moves the code we're using for breadcrumbs to the Settings framework. This is done for the same reasons as https://github.com/siteorigin/settings/pull/67. Basically, if we need to update it we normally have to update each theme individually. After this PR, we just need to update the Settings framework.