### PR TITLE
Fonts: Resolve PHP 8 Deprecated notice

### DIFF
--- a/inc/css_functions.php
+++ b/inc/css_functions.php
@@ -28,7 +28,7 @@ class SiteOrigin_Settings_CSS_Functions {
 
 		$return .= 'font-family: "' . esc_attr( $args['font'] ) . '"' . ( ! empty( $args['category'] ) ? ', ' . $args['category'] : '' ) . '; ';
 
-		if ( strpos( $args['variant'], 'italic' ) !== false ) {
+		if ( ! empty( $args['variant'] ) && strpos( $args['variant'], 'italic' ) !== false ) {
 			$weight = str_replace( 'italic', '', $args['variant'] );
 			$return .= 'font-style: italic; ';
 		} else {


### PR DESCRIPTION
Resolves the following notice:

`Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in wp-content/themes/siteorigin-north/inc/settings/inc/css_functions.php on line 31`