### PR TITLE
Page Settings: Remove Space After Setting Name

### DIFF
--- a/css/page-settings.css
+++ b/css/page-settings.css
@@ -3,7 +3,7 @@
 #siteorigin_page_settings .inside label {
   text-transform: capitalize; }
 #siteorigin_page_settings p:not(.description) {
-  margin: 1em 0; }
+  margin: 1em 0 0; }
 .edit-post-meta-boxes-area #poststuff #siteorigin_page_settings h2.hndle {
 	font-size: 13px;
 	font-weight: 500;

--- a/css/page-settings.css
+++ b/css/page-settings.css
@@ -3,7 +3,7 @@
 #siteorigin_page_settings .inside label {
   text-transform: capitalize; }
 #siteorigin_page_settings p:not(.description) {
-  margin: 1em 0 0; }
+  margin: 1em 0 0.25em; }
 .edit-post-meta-boxes-area #poststuff #siteorigin_page_settings h2.hndle {
 	font-size: 13px;
 	font-weight: 500;

--- a/css/page-settings.scss
+++ b/css/page-settings.scss
@@ -8,7 +8,7 @@
 	}
 	
 	p:not(.description) {
-		margin: 1em 0;
+		margin: 1em 0 0;
 	}
 
 	.edit-post-meta-boxes-area #poststuff & h2.hndle {

--- a/css/page-settings.scss
+++ b/css/page-settings.scss
@@ -8,7 +8,7 @@
 	}
 	
 	p:not(.description) {
-		margin: 1em 0 0;
+		margin: 1em 0 0.25em;
 	}
 
 	.edit-post-meta-boxes-area #poststuff & h2.hndle {


### PR DESCRIPTION
Before:
![Screenshot 2023-08-26 at 21-54-28 Edit Page “Vantage Metaslider Issue Fix” ‹ SO — WordPress](https://github.com/siteorigin/settings/assets/17275120/ccf7065f-bf9f-43a3-af11-d46512aa43a8)

After:
![Screenshot 2023-08-26 at 21-54-10 Edit Page “Vantage Metaslider Issue Fix” ‹ SO — WordPress](https://github.com/siteorigin/settings/assets/17275120/e3ceb641-4166-4786-8b5b-d5bc441a7155)


