### PR TITLE
Page Settings: Resolve Warning

### DIFF
--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -272,8 +272,11 @@ class SiteOrigin_Settings_Page_Settings {
 		foreach ( $this->get_settings( $post_type, $post_id ) as $id => $field ) {
 			switch( $field['type'] ) {
 				case 'select':
-					if ( !in_array( $settings[$id], array_keys( $field['options'] ) ) ) {
-						$settings[$id] = isset( $field['default'] ) ? $field['default'] : null;
+					if (
+						isset( $settings[ $id ] ) &&
+						! in_array( $settings[ $id ], array_keys( $field['options'] ) )
+					) {
+						$settings[ $id ] = isset( $field['default'] ) ? $field['default'] : null;
 					}
 					break;
 


### PR DESCRIPTION
Resolve the following warning:

`[31-Dec-2023 17:41:43 UTC] PHP Warning:  Undefined array key "overlap" in themes/siteorigin-corp/inc/settings/inc/page_settings.php on line 275`

(The error occurred while Corp was active, but it's specifically related to the Settings framework)