### PR TITLE
Add Filter to Control Page Setting During Output

### DIFF
--- a/inc/page_settings.php
+++ b/inc/page_settings.php
@@ -66,12 +66,18 @@ class SiteOrigin_Settings_Page_Settings {
 			$single->meta[ $type . '_' . $id ] = $single->get_settings_values( $type, $id );
 		}
 
-		// Return the value
+
 		if ( empty( $key ) ) {
-			return $single->meta[ $type . '_' . $id ];
+			$value = $single->meta[ $type . '_' . $id ];
 		} else {
-			return isset( $single->meta[ $type . '_' . $id ][ $key ] ) ? $single->meta[ $type . '_' . $id ][ $key ] : $default;
+			$value = isset( $single->meta[ $type . '_' . $id ][ $key ] ) ? $single->meta[ $type . '_' . $id ][ $key ] : $default;
 		}
+
+		return apply_filters(
+			'siteorigin_page_setting_get_' . $key,
+			$value,
+			$default
+		);
 	}
 
 	public function get_settings( $type, $id ) {


### PR DESCRIPTION
This PR allows developers to change the Page Setting value during output. For example, the following snippet will enforce that the Page Title is disabled.

`add_filter( 'siteorigin_page_setting_get_page_title', '__return_false' );`